### PR TITLE
CombineChartRenderer中内嵌的render没有必要实例化具体对象

### DIFF
--- a/chart/src/main/java/cn/jingzhuan/lib/chart2/renderer/CombineChartRenderer.java
+++ b/chart/src/main/java/cn/jingzhuan/lib/chart2/renderer/CombineChartRenderer.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 public class CombineChartRenderer extends AbstractDataRenderer {
 
-    protected BarChartRenderer barChartRenderer;
-    protected LineRenderer lineRenderer;
-    protected CandlestickChartRenderer candlestickChartRenderer;
-    protected ScatterChartRenderer scatterChartRenderer;
+    protected AbstractDataRenderer barChartRenderer;
+    protected AbstractDataRenderer lineRenderer;
+    protected AbstractDataRenderer candlestickChartRenderer;
+    protected AbstractDataRenderer scatterChartRenderer;
 
     private CombineData combineData;
 


### PR DESCRIPTION
在CombineChartRenderer中没有使用具体实例类的特性，也就没有声明具体化对象。